### PR TITLE
Don't encode '/' in the path part of the URL

### DIFF
--- a/src/fin1te/SafeCurl/Url.php
+++ b/src/fin1te/SafeCurl/Url.php
@@ -199,7 +199,7 @@ class Url {
               : '';
 
         $url .= (!empty($parts['path'])) 
-              ? '/' . rawurlencode(substr($parts['path'], 1))
+              ? str_replace('%2F', '/', rawurlencode($parts['path']))
               : '';
 
         //The query string is difficult to encode properly


### PR DESCRIPTION
This seems to be problematic for some servers, check for example http://cdimage.debian.org/debian-cd/7.6.0/amd64/iso-cd/SHA256SUMS
Replacing a '/' with '%2F' in the path will result in a 404.
