### PR TITLE
Make domain checking not via regex

### DIFF
--- a/src/fin1te/SafeCurl/Options.php
+++ b/src/fin1te/SafeCurl/Options.php
@@ -207,10 +207,10 @@ class Options {
             return false;
         }
 
-        //For domains, a regex match is needed
+        //For domains, a case insensitive match is needed
         if ($type == 'domain') {
             foreach ($this->{$list}[$type] as $domain) {
-                if (preg_match('/^' . $domain . '$/i', $value)) {
+                if (!strcasecmp($domain, $value)) {
                     return true;
                 }
             }


### PR DESCRIPTION
Use a case-insensitive comparison instead of vulnerable regex comparison

Fixes vulnerability #24